### PR TITLE
Implementing Termination extension

### DIFF
--- a/src/fs/file_info.rs
+++ b/src/fs/file_info.rs
@@ -29,10 +29,11 @@ pub struct Terminated;
 
 /// A struct representing a file and its metadata during various stages of processing.
 ///
-/// The struct has four possible states: [`Built`], [`Created`], and [`Completed`].
+/// The struct has four possible states: [`Built`], [`Created`], [`Completed`] and [`Terminated`].
 /// - [`Built`] - The file instances has been built and is ready to create information on disk.
 /// - [`Created`] - The file information has been saved on disk.
 /// - [`Completed`] - The file has been fully processed and is ready to be used.
+/// - [`Terminated`] - The file has been terminated and is no longer saved on disk.
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 pub struct FileInfo<State = Building> {

--- a/src/fs/file_info.rs
+++ b/src/fs/file_info.rs
@@ -23,6 +23,10 @@ pub struct Created;
 #[derive(Default, Debug)]
 pub struct Completed;
 
+/// Indicates the [`FileInfo`] `Terminated` state.
+#[derive(Default, Debug)]
+pub struct Terminated;
+
 /// A struct representing a file and its metadata during various stages of processing.
 ///
 /// The struct has four possible states: [`Built`], [`Created`], and [`Completed`].
@@ -125,6 +129,17 @@ impl FileInfo<Created> {
 
 impl FileInfo<Completed> {
     /// Returns where the file is located
+    pub fn file_name(&self) -> &String {
+        &self.file_name
+    }
+}
+
+impl FileInfo<Terminated> {
+    pub fn offset(&self) -> &u64 {
+        &self.offset
+    }
+
+    /// Returns where the file was located
     pub fn file_name(&self) -> &String {
         &self.file_name
     }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -2,6 +2,6 @@ mod file_info;
 mod metadata;
 mod vault;
 
-pub use file_info::{Built, Completed, Created, FileInfo};
+pub use file_info::{Built, Completed, Created, FileInfo, Terminated};
 pub use metadata::{Metadata, MetadataError};
 pub use vault::{LocalVault, PatchOption, Vault};

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,14 +1,14 @@
 mod creation;
 mod file_info;
 mod info;
-// mod termination;
+mod termination;
 mod upload;
 
 pub use creation::creation_handler;
 pub use file_info::file_info_handler;
 pub use info::info_handler;
 use rocket::{Orbit, Rocket};
-// pub use termination::termination_handler;
+pub use termination::termination_handler;
 pub use upload::upload_handler;
 
 use crate::fs::FileInfo;

--- a/src/handlers/termination.rs
+++ b/src/handlers/termination.rs
@@ -1,12 +1,49 @@
-use rocket::{Orbit, State};
+use std::sync::Arc;
 
-use crate::Meteoritus;
+use rocket::{
+    http::Status,
+    response::{self, Responder},
+    Orbit, Request, State,
+};
 
-#[delete("/")]
-pub fn termination_handler(meteoritus: &State<Meteoritus<Orbit>>) {
-    // do resources termination
+use crate::{Meteoritus, Vault};
 
-    if let Some(callback) = &meteoritus.on_termination() {
-        callback();
+#[delete("/<id>")]
+pub fn termination_handler(
+    id: &str,
+    vault: &State<Arc<dyn Vault>>,
+    meteoritus: &State<Meteoritus<Orbit>>,
+) -> TerminationResponder {
+    match vault.terminate_file(id) {
+        Err(_) => TerminationResponder::Failure,
+        Ok(_) => {
+            if let Some(callback) = &meteoritus.on_termination() {
+                callback();
+            }
+
+            TerminationResponder::Success
+        }
+    }
+}
+
+pub enum TerminationResponder {
+    Success,
+    Failure,
+}
+
+impl<'r> Responder<'r, 'static> for TerminationResponder {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+        let meteoritus = req.rocket().state::<Meteoritus<Orbit>>().unwrap();
+
+        let mut res = rocket::Response::build();
+
+        res.header(meteoritus.get_protocol_resumable_version());
+
+        match self {
+            Self::Success => res.status(Status::NoContent),
+            Self::Failure => res.status(Status::Gone),
+        };
+
+        res.ok()
     }
 }

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -41,6 +41,10 @@ pub async fn upload_handler(
                 });
             };
 
+            if let Err(_) = vault.terminate_file(id) {
+                return UploadResponder::Failure(Status::InternalServerError);
+            };
+
             *file.length()
         }
     };

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -41,9 +41,13 @@ pub async fn upload_handler(
                 });
             };
 
-            if let Err(_) = vault.terminate_file(id) {
-                return UploadResponder::Failure(Status::InternalServerError);
-            };
+            if meteoritus.auto_terminate() {
+                if let Err(_) = vault.terminate_file(id) {
+                    return UploadResponder::Failure(
+                        Status::InternalServerError,
+                    );
+                };
+            }
 
             *file.length()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,8 @@ pub use crate::meteoritus::Meteoritus;
 
 mod fs;
 pub use crate::fs::{
-    Built, Completed, Created, FileInfo, Metadata, MetadataError, Vault,
+    Built, Completed, Created, FileInfo, Metadata, MetadataError, Terminated,
+    Vault,
 };
 
 /* mod comet_vault;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@
 //!           .on_completed(|ctx| {
 //!                println!("on_completed: {:?}", ctx);
 //!            })
+//!           .on_termination(|ctx| {
+//!                println!("on_termination: {:?}", ctx);
+//!            })
 //!         .build();
 //!
 //!     rocket::build()
@@ -76,9 +79,6 @@ pub use crate::fs::{
     Built, Completed, Created, FileInfo, Metadata, MetadataError, Terminated,
     Vault,
 };
-
-/* mod comet_vault;
-pub use crate::comet_vault::{CometFile, CometVault}; */
 
 mod handlers;
 pub use crate::handlers::HandlerContext;

--- a/src/meteoritus.rs
+++ b/src/meteoritus.rs
@@ -6,9 +6,12 @@ use rocket::{
     Build, Ignite, Orbit, Phase, Rocket,
 };
 
-use crate::handlers::{
-    creation_handler, file_info_handler, info_handler, termination_handler,
-    upload_handler,
+use crate::{
+    fs::Terminated,
+    handlers::{
+        creation_handler, file_info_handler, info_handler, termination_handler,
+        upload_handler,
+    },
 };
 
 #[allow(unused_imports)]
@@ -152,7 +155,8 @@ pub struct Meteoritus<P: Phase> {
     >,
     on_created: Option<Arc<dyn Fn(HandlerContext<Created>) + Send + Sync>>,
     on_completed: Option<Arc<dyn Fn(HandlerContext<Completed>) + Send + Sync>>,
-    on_termination: Option<Arc<dyn Fn() + Send + Sync>>,
+    on_termination:
+        Option<Arc<dyn Fn(HandlerContext<Terminated>) + Send + Sync>>,
     state: std::marker::PhantomData<P>,
 }
 
@@ -537,7 +541,7 @@ impl Meteoritus<Build> {
 
     pub fn on_termination<F>(mut self, callback: F) -> Self
     where
-        F: Fn() + Send + Sync + 'static,
+        F: Fn(HandlerContext<Terminated>) + Send + Sync + 'static,
     {
         self.on_termination = Some(Arc::new(callback));
         self
@@ -596,7 +600,7 @@ impl Meteoritus<Orbit> {
 
     pub(crate) fn on_termination(
         &self,
-    ) -> &Option<Arc<dyn Fn() + Send + Sync>> {
+    ) -> &Option<Arc<dyn Fn(HandlerContext<Terminated>) + Send + Sync>> {
         &self.on_termination
     }
 }


### PR DESCRIPTION
Adding [`Termination extension` ](https://tus.io/protocols/resumable-upload.html#termination) functionality to `Meteoritus` library. 
This feature adds:

1. Capability to auto delete or keep temp files when upload is completed `keep_on_disk()`  flag.
2. tus protocol extension support to handle termination from client side requests.