### PR TITLE
Removing unstable features from library code

### DIFF
--- a/src/fs/file_info.rs
+++ b/src/fs/file_info.rs
@@ -86,8 +86,17 @@ impl FileInfo<Building> {
     pub(super) fn build(self) -> FileInfo<Built> {
         FileInfo::<Built> {
             state: std::marker::PhantomData,
-            ..self
+            id: self.id,
+            length: self.length,
+            offset: self.offset,
+            metadata: self.metadata,
+            file_name: self.file_name,
         }
+        /* Consider Update to: #![feature(type_changing_struct_update)]
+        FileInfo::<Built> {
+            state: std::marker::PhantomData,
+            ..self
+        } */
     }
 }
 
@@ -96,8 +105,17 @@ impl FileInfo<Built> {
         FileInfo::<Created> {
             file_name: file_name.to_string(),
             state: std::marker::PhantomData,
-            ..self
+            id: self.id,
+            length: self.length,
+            offset: self.offset,
+            metadata: self.metadata,
         }
+        /* Consider Update to: #![feature(type_changing_struct_update)]
+        FileInfo::<Created> {
+            file_name: file_name.to_string(),
+            state: std::marker::PhantomData,
+            ..self
+        } */
     }
 }
 
@@ -123,8 +141,17 @@ impl FileInfo<Created> {
 
         Some(FileInfo::<Completed> {
             state: std::marker::PhantomData,
-            ..self
+            id: self.id,
+            length: self.length,
+            offset: self.offset,
+            metadata: self.metadata,
+            file_name: self.file_name,
         })
+        /* Consider Update to: #![feature(type_changing_struct_update)]
+        Some(FileInfo::<Completed> {
+            state: std::marker::PhantomData,
+            ..self
+        }) */
     }
 }
 

--- a/src/fs/vault.rs
+++ b/src/fs/vault.rs
@@ -136,7 +136,7 @@ impl Vault for LocalVault {
         /* Retrieving disk file_name as &str */
         let Some(file_name) = file_name.as_path().to_str() else {
             return Err(VaultError::CreationError(Box::new(
-                std::io::Error::from(ErrorKind::InvalidFilename),
+                std::io::Error::from(ErrorKind::InvalidInput), // ErrorKind::InvalidFilename
             )))
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![doc(
     html_favicon_url = "https://github.com/kallebysantos/meteoritus/raw/main/assets/favicon.ico"
 )]
-#![feature(type_changing_struct_update)]
 //!  # Meteoritus - API Documentation
 //!
 //! Hello, and welcome to the Meteoritus API documentation!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_favicon_url = "https://github.com/kallebysantos/meteoritus/raw/main/assets/favicon.ico"
 )]
-#![feature(file_create_new)]
+
 #![feature(type_changing_struct_update)]
 #![feature(io_error_more)]
 //!  # Meteoritus - API Documentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,7 @@
 #![doc(
     html_favicon_url = "https://github.com/kallebysantos/meteoritus/raw/main/assets/favicon.ico"
 )]
-
 #![feature(type_changing_struct_update)]
-#![feature(io_error_more)]
 //!  # Meteoritus - API Documentation
 //!
 //! Hello, and welcome to the Meteoritus API documentation!

--- a/src/meteoritus.rs
+++ b/src/meteoritus.rs
@@ -199,8 +199,20 @@ impl Meteoritus<Build> {
     pub fn build(self) -> Meteoritus<Ignite> {
         Meteoritus::<Ignite> {
             state: std::marker::PhantomData,
-            ..self
+            auto_terminate: self.auto_terminate,
+            base_route: self.base_route,
+            max_size: self.max_size,
+            vault: self.vault,
+            on_creation: self.on_creation,
+            on_created: self.on_created,
+            on_completed: self.on_completed,
+            on_termination: self.on_termination,
         }
+        /*  Consider Update to: #![feature(type_changing_struct_update)]
+        Meteoritus::<Ignite> {
+            state: std::marker::PhantomData,
+            ..self
+        } */
     }
 
     /// Optional configuration that specifies if completed uploads should be keep on disk or deleted.
@@ -605,13 +617,25 @@ impl Meteoritus<Ignite> {
     pub(crate) fn launch(&self) -> Meteoritus<Orbit> {
         Meteoritus::<Orbit> {
             state: std::marker::PhantomData,
+            auto_terminate: self.auto_terminate,
+            base_route: self.base_route,
+            max_size: self.max_size,
+            vault: self.vault.to_owned(),
+            on_creation: self.on_creation.to_owned(),
+            on_created: self.on_created.to_owned(),
+            on_completed: self.on_completed.to_owned(),
+            on_termination: self.on_termination.to_owned(),
+        }
+        /*  Consider Update to: #![feature(type_changing_struct_update)]
+        Meteoritus::<Orbit> {
+            state: std::marker::PhantomData,
             vault: self.vault.to_owned(),
             on_creation: self.on_creation.to_owned(),
             on_created: self.on_created.to_owned(),
             on_completed: self.on_completed.to_owned(),
             on_termination: self.on_termination.to_owned(),
             ..*self
-        }
+        } */
     }
 }
 


### PR DESCRIPTION
### The following, three unstable feature flags has been omitted and refactored to `stable` code.
- ``#![feature(file_create_new)]``
- ``#![feature(type_changing_struct_update)]``
- ``#![feature(io_error_more)]``